### PR TITLE
Handle expandable pane in client mode

### DIFF
--- a/.changeset/shy-buses-design.md
+++ b/.changeset/shy-buses-design.md
@@ -1,0 +1,5 @@
+---
+'@darkmagic/react': patch
+---
+
+Fixing expandable pane in client mode

--- a/packages/react/src/components/pane.tsx
+++ b/packages/react/src/components/pane.tsx
@@ -376,11 +376,11 @@ const Root = React.forwardRef<React.ElementRef<typeof StyledPane>, PaneProps>(fu
             <StyledActions>
               {slots.actions}
 
-              {expandable && expanded ? (
+              {expandable && expanded && isClient ? (
                 <DialogPrimitive.Close asChild>
                   <IconButton icon={ExitFullScreenIcon} label="exit fullscreen" variant="secondary" />
                 </DialogPrimitive.Close>
-              ) : expandable ? (
+              ) : expandable && isClient ? (
                 <DialogPrimitive.Trigger asChild>
                   <IconButton icon={EnterFullScreenIcon} label="enter fullscreen" variant="secondary" />
                 </DialogPrimitive.Trigger>


### PR DESCRIPTION
I've noticed that the expandable pane story threw an `DialogTrigger must be used within Dialog` error: https://darkmagic.magicbell.com/storybook?path=/story/primitives-pane--expandable

This applies the same solution we use in the card component and fixes the error:

https://github.com/magicbell/darkmagic/blob/508148d7ef207f99b0e209ada89423d3d4df7c3d/packages/react/src/components/card.tsx#L296-L304

## Test Plan

- `yarn start:storybook`
- Tested on http://localhost:6006/?path=/story/primitives-pane--expandable